### PR TITLE
chore: replace lightning-fs with memfs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "tests"
       ],
       "dependencies": {
-        "@isomorphic-git/lightning-fs": "^4.6.0",
         "assert": "^2.1.0",
         "babel-bundle": "file:./playwright/packages/playwright/bundles/babel",
         "browserify-zlib": "^0.2.0",
@@ -25,6 +24,7 @@
         "expect-bundle": "file:./playwright/packages/playwright/bundles/expect",
         "https-browserify": "^1.0.0",
         "inspector": "^0.5.0",
+        "memfs": "^4.6.0",
         "os-browserify": "^0.3.0",
         "path": "^0.12.7",
         "process": "^0.11.10",
@@ -893,23 +893,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@isomorphic-git/idb-keyval": {
-      "version": "3.3.2",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@isomorphic-git/lightning-fs": {
-      "version": "4.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "@isomorphic-git/idb-keyval": "3.3.2",
-        "isomorphic-textencoder": "1.0.1",
-        "just-debounce-it": "1.1.0",
-        "just-once": "1.1.0"
-      },
-      "bin": {
-        "superblocktxt": "src/superblocktxt.js"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "license": "MIT",
@@ -1130,6 +1113,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/asn1.js": {
       "version": "5.4.1",
@@ -1710,9 +1698,11 @@
       "resolved": "playwright/packages/playwright/bundles/expect",
       "link": true
     },
-    "node_modules/fast-text-encoding": {
-      "version": "1.0.6",
-      "license": "Apache-2.0"
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "peer": true
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -1933,6 +1923,14 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "engines": {
+        "node": ">=10.18"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "funding": [
@@ -2074,13 +2072,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/isomorphic-textencoder": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "fast-text-encoding": "^1.0.0"
-      }
-    },
     "node_modules/jackspeak": {
       "version": "2.3.6",
       "dev": true,
@@ -2112,6 +2103,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-joy": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.9.1.tgz",
+      "integrity": "sha512-/d7th2nbQRBQ/nqTkBe6KjjvDciSwn9UICmndwk3Ed/Bk9AqkTRm4PnLVfXG4DKbT0rEY0nKnwE7NqZlqKE6kg==",
+      "dependencies": {
+        "arg": "^5.0.2",
+        "hyperdyperid": "^1.2.0"
+      },
+      "bin": {
+        "jj": "bin/jj.js",
+        "json-pack": "bin/json-pack.js",
+        "json-pack-test": "bin/json-pack-test.js",
+        "json-patch": "bin/json-patch.js",
+        "json-patch-test": "bin/json-patch-test.js",
+        "json-pointer": "bin/json-pointer.js",
+        "json-pointer-test": "bin/json-pointer-test.js",
+        "json-unpack": "bin/json-unpack.js"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "quill-delta": "^5",
+        "rxjs": "7",
+        "tslib": "2"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2123,13 +2144,17 @@
         "node": ">=6"
       }
     },
-    "node_modules/just-debounce-it": {
-      "version": "1.1.0",
-      "license": "MIT"
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "peer": true
     },
-    "node_modules/just-once": {
-      "version": "1.1.0",
-      "license": "MIT"
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -2157,6 +2182,25 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.6.0.tgz",
+      "integrity": "sha512-I6mhA1//KEZfKRQT9LujyW6lRbX7RkC24xKododIDO3AGShcaFAMKElv1yFGWX8fD4UaSiwasr3NeQ5TdtHY1A==",
+      "dependencies": {
+        "json-joy": "^9.2.0",
+        "thingies": "^1.11.1"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/miller-rabin": {
@@ -2489,6 +2533,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quill-delta": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "peer": true,
+      "dependencies": {
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "license": "MIT",
@@ -2615,6 +2673,15 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -2858,6 +2925,17 @@
       "resolved": "playwright/packages/playwright/bundles/utils",
       "link": true
     },
+    "node_modules/thingies": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.12.0.tgz",
+      "integrity": "sha512-AiGqfYC1jLmJagbzQGuoZRM48JPsr9yB734a7K6wzr34NMhjUPrWSQrkF7ZBybf3yCerCL2Gcr02kMv4NmaZfA==",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "license": "MIT",
@@ -2868,6 +2946,12 @@
     "node_modules/todomvc-crx": {
       "resolved": "examples/todomvc-crx",
       "link": true
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@isomorphic-git/lightning-fs": "^4.6.0",
     "assert": "^2.1.0",
     "babel-bundle": "file:./playwright/packages/playwright/bundles/babel",
     "browserify-zlib": "^0.2.0",
@@ -65,6 +64,7 @@
     "expect-bundle": "file:./playwright/packages/playwright/bundles/expect",
     "https-browserify": "^1.0.0",
     "inspector": "^0.5.0",
+    "memfs": "^4.6.0",
     "os-browserify": "^0.3.0",
     "path": "^0.12.7",
     "process": "^0.11.10",

--- a/src/server/crx.ts
+++ b/src/server/crx.ts
@@ -58,9 +58,9 @@ export class Crx extends SdkObject {
       protocolLogger: helper.debugProtocolLogger(),
       browserLogsCollector,
       originalLaunchOptions: {},
-      artifactsDir: '.',
-      downloadsPath: '.',
-      tracesDir: '.',
+      artifactsDir: '/crx/artifacts',
+      downloadsPath: '/crx/downloads',
+      tracesDir: '/crx/traces',
       ...options
     };
     const browser = await CRBrowser.connect(this.attribution.playwright, transport, browserOptions);

--- a/src/shims/fs/index.ts
+++ b/src/shims/fs/index.ts
@@ -14,26 +14,104 @@
  * limitations under the License.
  */
 
-import FS from '@isomorphic-git/lightning-fs';
+import { fs } from 'memfs';
 
-const fs = new FS('crx');
-const noop = () => ({});;
+export const {
+  appendFile,
+  appendFileSync,
+  access,
+  accessSync,
+  chown,
+  chownSync,
+  chmod,
+  chmodSync,
+  close,
+  closeSync,
+  copyFile,
+  copyFileSync,
+  cp,
+  cpSync,
+  createReadStream,
+  createWriteStream,
+  exists,
+  existsSync,
+  fchown,
+  fchownSync,
+  fchmod,
+  fchmodSync,
+  fdatasync,
+  fdatasyncSync,
+  fstat,
+  fstatSync,
+  fsync,
+  fsyncSync,
+  ftruncate,
+  ftruncateSync,
+  futimes,
+  futimesSync,
+  lchown,
+  lchownSync,
+  lchmod,
+  lchmodSync,
+  link,
+  linkSync,
+  lstat,
+  lstatSync,
+  lutimes,
+  lutimesSync,
+  mkdir,
+  mkdirSync,
+  mkdtemp,
+  mkdtempSync,
+  open,
+  openSync,
+  opendir,
+  opendirSync,
+  readdir,
+  readdirSync,
+  read,
+  readSync,
+  readv,
+  readvSync,
+  readFile,
+  readFileSync,
+  readlink,
+  readlinkSync,
+  realpath,
+  realpathSync,
+  rename,
+  renameSync,
+  rm,
+  rmSync,
+  rmdir,
+  rmdirSync,
+  stat,
+  statfs,
+  statSync,
+  statfsSync,
+  symlink,
+  symlinkSync,
+  truncate,
+  truncateSync,
+  unwatchFile,
+  unlink,
+  unlinkSync,
+  utimes,
+  utimesSync,
+  watch,
+  watchFile,
+  writeFile,
+  writeFileSync,
+  write,
+  writeSync,
+  writev,
+  writevSync,
+  Dirent,
+  Stats,
+  ReadStream,
+  WriteStream,
+  constants,
+  promises,
+} = fs;
 
 export default fs;
-export const { promises, readFile, readlink, rename, readdir, stat, lstat } = fs;
-
-export const chmodSync = noop;
-export const createWriteStream = noop;
-export const existsSync = noop;
-export const lstatSync = noop;
-export const mkdirSync = noop;
-export const readdirSync = noop;
-export const readFileSync = noop;
-export const readlinkSync = noop;
-export const realpathSync = noop;
-export const renameSync = noop;
-export const rmdirSync = noop;
-export const rmSync = noop;
-export const statSync = noop;
-export const unlinkSync = noop;
-export const writeFileSync = noop;

--- a/src/shims/fs/promises.ts
+++ b/src/shims/fs/promises.ts
@@ -1,5 +1,37 @@
 import { promises } from "./index";
 
-export const { readFile, readlink, rename, readdir, stat, lstat } = promises;
+export const {
+  access,
+  copyFile,
+  cp,
+  open,
+  opendir,
+  rename,
+  truncate,
+  rm,
+  rmdir,
+  mkdir,
+  readdir,
+  readlink,
+  symlink,
+  lstat,
+  stat,
+  statfs,
+  link,
+  unlink,
+  chmod,
+  lchmod,
+  lchown,
+  chown,
+  utimes,
+  lutimes,
+  realpath,
+  mkdtemp,
+  writeFile,
+  appendFile,
+  readFile,
+  watch,
+  constants,
+} = promises;
 
-export const realpath = () => ({});
+export default promises;

--- a/src/shims/global.ts
+++ b/src/shims/global.ts
@@ -17,6 +17,10 @@
 import './process';
 import './setImmediate';
 import './buffer';
+import { fs } from 'memfs';
+
+fs.mkdirSync('/tmp');
+fs.mkdirSync('/crx');
 
 self.global = self;
-self.__dirname = '.';
+self.__dirname = '/crx';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,7 +62,6 @@ export default defineConfig({
 
       // shims
       '_util': path.resolve(__dirname, './node_modules/util'),
-      '@isomorphic-git/lightning-fs': path.resolve(__dirname, './node_modules/@isomorphic-git/lightning-fs'),
       'assert': path.resolve(__dirname, './node_modules/assert'),
       'buffer': path.resolve(__dirname, './node_modules/buffer'),
       'child_process': path.resolve(__dirname, './src/shims/child_process'),


### PR DESCRIPTION
memfs has FS sync methods, and we don't need actual persistence, at least for now